### PR TITLE
Correct Shift + Keypad 9 to output PgUp in numlock mode

### DIFF
--- a/src/ria/usb/kbd.c
+++ b/src/ria/usb/kbd.c
@@ -124,8 +124,8 @@ static void kbd_queue_key(uint8_t modifier, uint8_t keycode, bool initial_press)
         case HID_KEY_KEYPAD_8:
             keycode = HID_KEY_ARROW_UP;
             break;
-        case HID_KEY_PAGE_UP:
-            keycode = HID_KEY_END;
+        case HID_KEY_KEYPAD_9:
+            keycode = HID_KEY_PAGE_UP;
             break;
         case HID_KEY_KEYPAD_0:
             keycode = HID_KEY_INSERT;


### PR DESCRIPTION
Like I said in an Azerty's PR comment.