### PR TITLE
small fixes for MacOS

### DIFF
--- a/src/emu/api/clk.c
+++ b/src/emu/api/clk.c
@@ -15,6 +15,11 @@
 #include <string.h>
 #include <time.h>
 
+#if defined(__APPLE__)
+size_t strftime_l(char *restrict, size_t, const char *restrict,
+                  const struct tm *restrict, locale_t);
+#endif
+
 /* Host locale used only for strftime, so the rest of the process stays in the
  * C locale. NULL if the environment locale isn't installed (falls back to C). */
 static locale_t g_locale;

--- a/src/emu/app/app_sokol.c
+++ b/src/emu/app/app_sokol.c
@@ -61,6 +61,7 @@ double emu_get_window_scale(void) { return 0.0; }
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <time.h> /* frame limiter (clock_gettime/clock_nanosleep) */
 #if defined(_WIN32)
 #include <windows.h>
@@ -126,6 +127,7 @@ static struct
     int tex_w, tex_h; /* current texture size = canvas native size */
     bool exit_on_halt; /* close the window when the program stops */
     bool vsync;        /* false: pace the loop to 60 Hz in software (sleep_until_ns) */
+    bool flip_v;       /* true on GL-family backends, false on Metal/D3D11 */
     sg_image img;
     sg_view view;
     sg_sampler smp;        /* NEAREST: the canvas texture / prescale source */
@@ -375,6 +377,8 @@ static void init_cb(void)
     sgl_setup(&(sgl_desc_t){
         .logger.func = slog_func,
     });
+    sg_backend b = sg_query_backend();
+    app.flip_v = (b == SG_BACKEND_GLCORE) || (b == SG_BACKEND_GLES3);
     app.smp = sg_make_sampler(&(sg_sampler_desc){
         .min_filter = SG_FILTER_NEAREST,
         .mag_filter = SG_FILTER_NEAREST,
@@ -436,9 +440,21 @@ static uint64_t now_ns(void)
 static void sleep_until_ns(uint64_t target)
 {
 #if !defined(__EMSCRIPTEN__) && !defined(_WIN32)
+#if defined(__APPLE__)
+    uint64_t now = now_ns();
+    if (target > now)
+    {
+        uint64_t delta = target - now;
+        struct timespec req = {.tv_sec = (time_t)(delta / 1000000000ull),
+                               .tv_nsec = (long)(delta % 1000000000ull)};
+        while (nanosleep(&req, &req) != 0 && errno == EINTR)
+            ;
+    }
+#else
     struct timespec until = {.tv_sec = (time_t)(target / 1000000000ull),
                              .tv_nsec = (long)(target % 1000000000ull)};
     clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &until, NULL);
+#endif
 #else
     (void)target;
 #endif
@@ -645,11 +661,14 @@ static void frame_cb(void)
         else
             sgl_texture(app.view, app.smp);
         sgl_begin_quads();
-        /* Texture v flipped so framebuffer row 0 is at the top. */
-        sgl_v2f_t2f(-qx, qy, 0.0f, 0.0f);
-        sgl_v2f_t2f(qx, qy, 1.0f, 0.0f);
-        sgl_v2f_t2f(qx, -qy, 1.0f, 1.0f);
-        sgl_v2f_t2f(-qx, -qy, 0.0f, 1.0f);
+        /* GL-family backends sample uploaded rows upside down vs the emulator's
+         * row-0-at-top framebuffer; Metal/D3D11 do not. */
+        float tv_top = app.flip_v ? 0.0f : 1.0f;
+        float tv_bot = app.flip_v ? 1.0f : 0.0f;
+        sgl_v2f_t2f(-qx, qy, 0.0f, tv_top);
+        sgl_v2f_t2f(qx, qy, 1.0f, tv_top);
+        sgl_v2f_t2f(qx, -qy, 1.0f, tv_bot);
+        sgl_v2f_t2f(-qx, -qy, 0.0f, tv_bot);
         sgl_end();
     }
 


### PR DESCRIPTION
MacOs: Tahoe 26.5.1 
Xcode: 26.5 

1. `strftime_l` declaration visibility in the clock API:
- File: [src/emu/api/clk.c](src/emu/api/clk.c)
- Change: add an Apple-only forward declaration for `strftime_l(...)`.
- Why: with this SDK/header exposure, `strftime_l` may not be visible from the default include path used by this target, which caused an implicit declaration compile error.

2. `clock_nanosleep` absolute sleep fallback in the frame pacer:
- File: [src/emu/app/app_sokol.c](src/emu/app/app_sokol.c)
- Change: on macOS, use relative `nanosleep` with EINTR retry instead of `clock_nanosleep(..., TIMER_ABSTIME, ...)`.
- Why: `clock_nanosleep` and/or `TIMER_ABSTIME` were not available in this build mode on macOS, causing compile failures.

3. Backend-specific vertical flip for emulator video:
- File: [src/emu/app/app_sokol.c](src/emu/app/app_sokol.c)
- Change: apply the final texture V-flip only on GL-family backends; leave Metal unflipped.
- Why: the emulator framebuffer is stored with row 0 at the top, but GL backends sample it upside down while Metal presents it upright.