### PR TITLE
Emulator for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /.venv/
+CMakeUserPresets.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,10 @@
             "externalConsole": false,
             "MIMode": "gdb",
             "preLaunchTask": "emu: Build (Debug)",
+            "windows": {
+                "program": "${workspaceFolder}/build/emulator/debug/rp6502-emu.exe",
+                "miDebuggerPath": "C:/msys64/ucrt64/bin/gdb.exe"
+            },
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",

--- a/EMULATOR_WINDOWS_MSYS2_VSCODE.md
+++ b/EMULATOR_WINDOWS_MSYS2_VSCODE.md
@@ -1,0 +1,226 @@
+# Building/running the desktop emulator on Windows via MSYS2 (UCRT64)
+
+`README.md` says nobody was working on the Windows emulator port. This document covers a
+second, working route that doesn't need Visual Studio: MSYS2's UCRT64 GCC toolchain. It does
+not replace or modify the MSVC path `README.md` describes — that's still unimplemented.
+
+Status: builds and runs natively, all 20 `ctest` suites pass, the D3D11 window renders.
+
+## Prerequisites
+
+- MSYS2 installed (default location `C:\msys64`).
+- The **UCRT64** environment with `gcc`, `cmake`, and `ninja` installed
+  (`C:\msys64\ucrt64\bin\gcc.exe`, `g++.exe`, `cmake.exe`, `ninja.exe`). Install via the
+  MSYS2 shell if missing:
+  ```
+  pacman -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja
+  ```
+
+## Command-line build
+
+From a shell with `C:\msys64\ucrt64\bin` **prepended** to `PATH` (this matters — see
+Troubleshooting below):
+
+```
+git submodule update --init --depth 1 vendor/chips vendor/sokol vendor/imgui vendor/cppdap vendor/wingetopt
+git -C vendor/cppdap submodule update --init --depth 1 third_party/json
+
+cmake -S src/emu -B build/emulator/win-release -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+cmake --build build/emulator/win-release
+ctest --test-dir build/emulator/win-release --output-on-failure
+```
+
+**Use Release, not Debug, for anything but active debugging.** Measured on this machine:
+rendering 600 emulated frames took 31.6s with a Debug build vs. 1.25s with Release — an
+optimized build is roughly 25x faster.
+
+## VS Code CMake Tools
+
+`src/emu/CMakePresets.json` puts the **emu** folder into CMake's *presets mode*. In that
+mode, VS Code CMake Tools hides the classic Kit-selection command
+(`cmake.selectKit`'s command-palette entry has `"when": "... && !useCMakePresets"` in the
+extension's own `package.json`) — there's no "Select a Kit" to reach for. The root
+**rp6502** folder has no `CMakePresets.json`, so it stays in Kit+Variant mode and "Select a
+Kit" works fine there (for the Pico/ARM firmware toolchain) — the two folders behave
+differently on purpose.
+
+In presets mode the compiler has to come from a preset's `cacheVariables`, and the
+project's own `src/emu/CMakePresets.json` (`debug`/`release`) doesn't set one — that's why
+plain configure falls through to PATH-searching and can pick up the wrong compiler (see
+Troubleshooting). The fix is a **`src/emu/CMakeUserPresets.json`** — CMake's standard,
+git-ignored, machine-local override file that gets merged with `CMakePresets.json`
+automatically:
+
+```json
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "win-debug",
+            "displayName": "Debug (MSYS2 UCRT64)",
+            "inherits": "debug",
+            "environment": {
+                "PATH": "C:/msys64/ucrt64/bin;$penv{PATH}"
+            },
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "C:/msys64/ucrt64/bin/gcc.exe",
+                "CMAKE_CXX_COMPILER": "C:/msys64/ucrt64/bin/g++.exe"
+            }
+        },
+        {
+            "name": "win-release",
+            "displayName": "Release (MSYS2 UCRT64)",
+            "inherits": "release",
+            "environment": {
+                "PATH": "C:/msys64/ucrt64/bin;$penv{PATH}"
+            },
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "C:/msys64/ucrt64/bin/gcc.exe",
+                "CMAKE_CXX_COMPILER": "C:/msys64/ucrt64/bin/g++.exe"
+            }
+        }
+    ],
+    "buildPresets": [
+        { "name": "win-debug", "configurePreset": "win-debug" },
+        { "name": "win-release", "configurePreset": "win-release" }
+    ]
+}
+```
+
+`environment.PATH` is not optional even with an explicit `CMAKE_C_COMPILER` path: `gcc.exe`
+spawns `cc1.exe` (the actual compiler) as a subprocess, and `cc1.exe` needs
+`ucrt64/bin` on `PATH` to resolve its own runtime DLLs (`libgcc_s_seh-1.dll` etc., which live
+in `ucrt64/bin`, not next to `cc1.exe`). Without it, `gcc.exe` fails with **zero diagnostic
+output** — confirmed while diagnosing this exact setup.
+
+This file is already in `.gitignore` — it's meant to stay local to each machine (adjust the
+`C:/msys64/...` paths if your MSYS2 lives elsewhere).
+
+To use it: in VS Code's CMake side panel, set Folder to **emu**, then Configure Preset →
+**"Debug (MSYS2 UCRT64)"** or **"Release (MSYS2 UCRT64)"**.
+
+## F5 debugging ("Emulator Debug") on Windows
+
+`.vscode/launch.json`'s **"Emulator Debug"** config (`type: cppdbg`, `MIMode: gdb`) was
+written for Linux/macOS and needed three fixes to work on Windows/MSYS2:
+
+1. **Install gdb** — only `gcc`/`cmake`/`ninja` are covered by the Prerequisites above;
+   the debugger is a separate package:
+   ```
+   pacman -S mingw-w64-ucrt-x86_64-gdb
+   ```
+2. **Wrong program filename.** The top-level `"program"` field points at
+   `build/emulator/debug/rp6502-emu` (no extension, correct for Linux/macOS). Windows needs
+   `rp6502-emu.exe`. Fixed with a `"windows"` platform-override block — VS Code merges this
+   in only when running on Windows, so the Linux/macOS fields are untouched:
+   ```jsonc
+   "windows": {
+       "program": "${workspaceFolder}/build/emulator/debug/rp6502-emu.exe",
+       "miDebuggerPath": "C:/msys64/ucrt64/bin/gdb.exe"
+   }
+   ```
+   `miDebuggerPath` is set explicitly (rather than relying on `gdb` being found via `PATH`)
+   so this works even before the `PATH` fix below takes effect.
+3. **PATH, again.** The `preLaunchTask` (`emu: Build (Debug)`) runs
+   `cmake --build --preset debug` — the *base* preset from the committed
+   `CMakePresets.json`, not the `win-debug` preset from `CMakeUserPresets.json` that carries
+   the `environment.PATH` fix (task and preset are independent; there's no way to make a
+   shared, committed task reference a gitignored, machine-local preset name without breaking
+   Linux/macOS/other Windows setups). Since this is really the same "process spawned without
+   `ucrt64/bin` on `PATH`" problem from the Troubleshooting section, but now hitting *every*
+   entry point VS Code has (tasks, launch configs, and CMake Tools alike) rather than just
+   configure, the durable fix is to add `C:\msys64\ucrt64\bin` to the **user's permanent
+   Windows PATH** once, outside VS Code:
+   ```
+   setx PATH "%PATH%;C:\msys64\ucrt64\bin"
+   ```
+   Requires restarting VS Code (and any open terminals) to take effect. After that, every
+   `process`-type task, launch config, and CMake Tools action inherits it automatically —
+   no more per-tool PATH workarounds needed (the `CMakeUserPresets.json` `environment.PATH`
+   entry becomes redundant belt-and-suspenders at that point, but harmless to leave in place).
+
+With all three in place, F5 → **Emulator Debug** builds, launches
+`rp6502-emu.exe --debug <rom>` under gdb, and stops/breaks normally.
+
+## Running from the Windows desktop (no MSYS2 shell needed)
+
+`src/emu/CMakeLists.txt` has a `WIN32 AND NOT MSVC` block that statically links the MinGW
+runtime into `rp6502-emu.exe`:
+
+```cmake
+if(WIN32 AND NOT MSVC)
+    target_link_options(rp6502-emu PRIVATE -static-libgcc -static-libstdc++ -static)
+endif()
+```
+
+This removes the executable's dependency on `libgcc_s_seh-1.dll`, `libwinpthread-1.dll`, and
+`libstdc++-6.dll` (everything else it needs — `d3d11.dll`, `USER32.dll`, the Universal CRT,
+etc. — already ships with Windows 10/11). The result runs standalone: point a desktop
+shortcut straight at `rp6502-emu.exe <rom.rp6502>`, no MSYS2 install or `PATH` changes
+required at runtime.
+
+## Troubleshooting
+
+- **Configure grabs `C:\llvm-mos\bin\clang.exe` and fails with `ld.lld: unable to find
+  library -lkernel32` (etc.)** — PATH/kit resolution found the 6502 cross-compiler instead
+  of a native one; it has no host CRT or link libraries. Use the `win-debug`/`win-release`
+  presets above (or pass `-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++` on the command
+  line from a shell with `ucrt64/bin` on `PATH`).
+- **`gcc.exe` fails with no error text at all, build just stops** — `ucrt64/bin` isn't on
+  `PATH`, so `cc1.exe` can't load its own DLLs. Fixed by the preset's `environment.PATH`
+  entry (command line: `export PATH="/c/msys64/ucrt64/bin:$PATH"` first).
+- **`[saudio][error][id:13][line:1721]` at runtime** — a non-fatal stock-sokol WASAPI
+  init failure (`IAudioClient::Initialize`, `vendor/sokol/sokol_audio.h`). The emulator keeps
+  running without sound. Pass `--mute` to skip trying, or check that your default playback
+  device isn't locked to exclusive mode by another app.
+- **F5 "Emulator Debug" fails to start / can't find the program / can't start gdb** — see
+  the dedicated section below; it's the same missing-`ucrt64/bin`-on-`PATH` issue plus a
+  Linux/macOS-only program path and a missing `gdb` package.
+- **F5 session starts, then gdb reports `error return .../windows-nat.c:2916 was 5: Odmowa
+  dostępu` (Access Denied), the program "exits" with a bogus code (e.g. 42), then
+  `... was 6: Invalid Handle`** — this isn't the emulator crashing or
+  returning that exit code itself (`src/emu/app/main.c` only ever returns 0/1/2); it's gdb's
+  Windows-native backend losing a `ContinueDebugEvent`/`WaitForDebugEvent` call, which happens
+  when antivirus behavior-monitoring intercepts the Windows debug APIs a native debugger
+  needs. Confirmed cause on this machine: **Avast**. Fix: add two exclusions in Avast
+  (Settings → General → Exceptions):
+  - `C:\msys64\ucrt64\bin\gdb.exe` — the debugger itself.
+  - `build\` (as a **folder** exclusion) — covers every
+    build output dir (`debug`/`release`/`win`/`win-release`) so new build dirs don't need a
+    fresh exclusion each time.
+  If exclusions alone don't fix it, temporarily disable Avast's "Self-Defense"/"Behavior
+  Shield" to confirm the hypothesis, then re-enable it with the exclusions in place. (Any
+  other antivirus with similar self-defense/behavior-monitoring features can cause the same
+  symptom — the fix is the same shape: exclude `gdb.exe` and the build output folder.)
+- **`[sapp][error][id:22] ... WIN32_D3D11_CREATE_DEVICE_AND_SWAPCHAIN_WITH_DEBUG_FAILED` at
+  startup** — harmless, Debug-build-only noise, unrelated to the above. `SOKOL_DEBUG` (auto-on
+  for Debug builds, since only Release defines `NDEBUG`) makes `sokol_app.h` request the D3D11
+  SDK debug layer (`D3D11_CREATE_DEVICE_DEBUG`), which needs the Windows optional "Graphics
+  Tools" feature that isn't installed by default. `sokol_app.h:8804-8850` already detects the
+  failure, strips the flag, and retries successfully — the window still opens fine. Ignore it,
+  or install "Graphics Tools" (Settings → Apps → Optional Features) purely to silence it.
+
+## What changed in the source tree
+
+MinGW's C library is close to POSIX but not complete; these files got small, mostly
+`#ifdef _WIN32`-guarded fixes for the real gaps (not a full inventory — see `git log`/
+`git diff` for exact lines):
+
+- `src/emu/posix/dir.c`, `src/emu/posix/fs.c` — mingw's `dirent` has no `d_type` (stat the
+  joined path instead), no `<sys/statvfs.h>` (use `GetDiskFreeSpaceExA`), `mkdir()` takes one
+  argument not two, and a new `fs_realpath()` (mingw has no `realpath()`) with `\`→`/`
+  normalization (mingw's `getcwd()`/`_fullpath()` return backslash paths).
+- `src/emu/plat.h` — added the `fs_realpath()` declaration to the portable seam.
+- `src/emu/api/clk.c` — POSIX-2008 `locale_t`/`newlocale`/`strftime_l` don't exist on mingw;
+  added the `_create_locale`/`_strftime_l` equivalents, including honoring `LC_ALL`/`LANG`
+  from the environment (mingw's `_create_locale(LC_ALL, "")` ignores them, unlike POSIX).
+- `src/emu/api/pro.c` — replaced the direct `realpath()` call with the new `fs_realpath()`.
+- `src/emu/host/msc.c`, `src/emu/mon/rom.c` — mingw has no `pread()` (added a small
+  `lseek`+`read` shim); `open()` needs `O_BINARY` on Windows or the CRT's text-mode read
+  stops dead at a `0x1A` byte (Ctrl-Z-as-EOF) — this was silently truncating file reads.
+- Several `src/emu/tests/*.c` files — `_WIN32` guards for `mkdir`/`realpath`/`setenv`
+  differences, a portable temp-directory helper (Windows has no `/tmp`), and updated
+  expected-path strings to account for Windows drive-letter paths (the existing
+  `MSC0://C/...` mapping in `host/msc.c` was already correct — only the tests' own
+  hand-built expectation strings needed fixing).

--- a/GITHUB_PR.md
+++ b/GITHUB_PR.md
@@ -1,0 +1,15 @@
+## Windows emulator support (MSYS2/UCRT64)
+
+Ports `src/emu` to build and run natively on Windows via MSYS2's UCRT64 GCC toolchain
+(previously unsupported — README said "nobody is working on the emulator for Windows").
+
+- Close mingw's POSIX gaps (no `d_type`, `<sys/statvfs.h>`, `pread`, POSIX locale API,
+  1-arg `mkdir`) in `posix/dir.c`, `posix/fs.c`, `api/clk.c`, `api/pro.c`, `host/msc.c`,
+  `mon/rom.c`; add `fs_realpath()` to the `plat.h` seam.
+- Statically link the MinGW runtime so `rp6502-emu.exe` runs standalone (no MSYS2 needed at
+  runtime).
+- Fix Windows gaps in the test suite (`mkdir`/`realpath`/`setenv`, no `/tmp`).
+- Fix Windows F5 debugging (`launch.json`).
+
+All 20 `ctest` suites pass; D3D11 window renders. Setup/troubleshooting:
+`EMULATOR_WINDOWS_MSYS2_VSCODE.md`.

--- a/MSVSBT.md
+++ b/MSVSBT.md
@@ -1,0 +1,108 @@
+# Installing Visual Studio Build Tools + VS Code for the "emu" folder (MSVC route)
+
+This is the *other* Windows route besides MSYS2/UCRT64 (see
+`EMULATOR_WINDOWS_MSYS2_VSCODE.md`) — the one `README.md` actually describes ("with MSVC
+configure from an x64 Native Tools prompt"). This document only covers **installation and
+VS Code wiring**. It does not install anything by itself — follow the steps manually.
+
+## Important caveat before you start
+
+Installing Build Tools alone will **not** make `rp6502-emu.exe` build successfully yet.
+`src/emu/win/dir.c` and `src/emu/win/fs.c` — the Win32 bodies of the portable
+`dir_*`/`fs_*` seam (`src/emu/plat.h`) that MSVC needs (mingw doesn't need them; it has its
+own POSIX-ish headers) — are still skeletons: every function is a `TODO(win)` comment plus
+`errno = ENOSYS; return false;` (confirmed: 27 such stub markers across the two files).
+Configure will succeed once a compiler is found, but the actual build will fail deep inside
+`emu_core` until those Win32 bodies are implemented (each `TODO(win)` comment names the exact
+Win32 API to call — `FindFirstFileW`, `GetFileAttributesExW`, `_wmkdir`, etc.). Treat this
+guide as "get MSVC recognized and configuring," not "get the emulator running."
+
+## 1. Install Visual Studio Build Tools
+
+**Option A — winget (fastest):**
+```
+winget install --id Microsoft.VisualStudio.2022.BuildTools --override "--wait --passive --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+**Option B — manual installer:**
+1. Download from https://visualstudio.microsoft.com/downloads/ → scroll to "Tools for Visual
+   Studio" → **Build Tools for Visual Studio 2022**.
+2. Run it. In the workload picker, check **"Desktop development with C++"**.
+3. On the right-hand summary pane, confirm these are included (default): MSVC v143 build
+   tools, Windows 11 SDK, C++ CMake tools for Windows (optional — the project uses its own
+   MSYS2/CMake or a separate CMake install, not required), C++ core features.
+4. Install (~2-3 GB). No reboot needed.
+
+This installs **no IDE** — just `cl.exe`, `link.exe`, the Windows SDK, and MSBuild, plus a
+**"Developer Command Prompt for VS 2022"** / **"x64 Native Tools Command Prompt for VS
+2022"** shortcut in the Start Menu (added by the installer).
+
+## 2. Verify the install
+
+Open **"x64 Native Tools Command Prompt for VS 2022"** from the Start Menu and run:
+```
+cl
+```
+You should see `Microsoft (R) C/C++ Optimizing Compiler Version ...` (not "command not
+found"). This confirms `cl.exe`/`link.exe`/the Windows SDK are on `PATH` **inside this
+specific shell only** — a plain `cmd.exe`/PowerShell/VS Code terminal opened normally will
+*not* have them, which is the crux of step 3.
+
+## 3. Launch VS Code with the MSVC environment loaded
+
+`cl.exe` isn't self-contained like `gcc.exe` — it also needs `INCLUDE`/`LIB`/`LIBPATH`
+environment variables set (for the CRT and Windows SDK headers/libs), which only the
+Developer Command Prompt's `vcvarsall.bat` sets up. The simplest way to get this into VS
+Code, **matching what `README.md` already recommends**, is to launch VS Code *from* that
+prompt rather than from the Start Menu/taskbar:
+
+1. Open **"x64 Native Tools Command Prompt for VS 2022"**.
+2. `cd` to the repo root:
+   ```
+   cd /d C:\@prg\@picocomputer\@firmware\rp6502
+   ```
+3. Launch VS Code from inside it:
+   ```
+   code .
+   ```
+
+VS Code (and everything it spawns — CMake Tools, integrated terminals, tasks, the debugger)
+inherits that environment for the lifetime of this window. **You need to repeat this every
+time you want to work on the MSVC build** — a normally-launched VS Code window won't have
+`cl.exe` on `PATH`.
+
+(A shortcut to make this less tedious: create a `.bat` file with those two commands and pin
+it to the Start Menu/taskbar instead of VS Code's own icon, for whenever you want the MSVC
+session specifically. Keep using the normal VS Code icon — or MSYS2 — for the MinGW route.)
+
+## 4. Configure the "emu" folder
+
+With VS Code launched per step 3, no CMakeUserPresets.json or kit selection should be
+needed — `cmake -S src/emu -B build/emulator/debug -G Ninja` (what the `debug`/`release`
+presets already do) will find `cl.exe` on `PATH` automatically, same as any other
+Ninja+MSVC setup. In the CMake side panel: Folder **emu** → Configure Preset → **debug** or
+**release** (the plain, existing presets — no MSYS2-specific override needed for this
+route).
+
+If configure instead complains it can't find a working C compiler, double check VS Code was
+actually launched from the Native Tools prompt (step 3) and not from a normal shell/shortcut
+— this is the most common mistake.
+
+## 5. Debugging (once the build actually succeeds)
+
+MSVC builds can use VS Code's native Windows debugger instead of gdb — add a
+`"windows"` override (or a separate configuration) to `.vscode/launch.json` using
+`"type": "cppvsdbg"` instead of `"cppdbg"`/`MIMode: gdb"`, pointing `program` at
+`build/emulator/debug/rp6502-emu.exe`. `cppvsdbg` doesn't need MSYS2's gdb at all, and in
+practice doesn't hit the antivirus/Windows-debug-API friction documented in
+`EMULATOR_WINDOWS_MSYS2_VSCODE.md` (Microsoft's own debug engine, not a third-party
+gdb.exe making raw Win32 debug API calls) — though this hasn't been verified end-to-end
+since the win/dir.c-fs.c gap (see the caveat above) currently blocks getting that far.
+
+## Coexisting with the MSYS2/UCRT64 setup
+
+No conflict: Build Tools and MSYS2 are independent installs. Which one gets used depends
+entirely on which VS Code window/terminal/preset you're working in — a normally-launched
+VS Code window (or the MSYS2 shell) still resolves to MinGW/UCRT64 as before; only a VS
+Code window launched per step 3 above sees `cl.exe`. `CMakeUserPresets.json`
+(`win-debug`/`win-release`, MSYS2-specific) is untouched by any of this.

--- a/src/emu/CMakeLists.txt
+++ b/src/emu/CMakeLists.txt
@@ -182,6 +182,12 @@ add_executable(rp6502-emu ${APP_SOURCES})
 target_link_libraries(rp6502-emu PRIVATE emu_core)
 target_include_directories(rp6502-emu PRIVATE ${RP6502_VENDOR}/sokol)
 
+if(WIN32 AND NOT MSVC)
+    # MinGW-only: fold libgcc/libstdc++/libwinpthread into the exe so it runs from a
+    # plain Windows desktop without MSYS2's ucrt64/bin on PATH.
+    target_link_options(rp6502-emu PRIVATE -static-libgcc -static-libstdc++ -static)
+endif()
+
 # Windows is only platform without getopt
 if(WIN32)
     add_subdirectory(${RP6502_VENDOR}/wingetopt wingetopt)

--- a/src/emu/CMakeLists.txt
+++ b/src/emu/CMakeLists.txt
@@ -74,9 +74,10 @@ add_library(emu_core STATIC
 )
 
 # Platform filesystem primitives: one folder compiled per OS; both define the same
-# dir_*/fs_* symbols (emu/plat.h), so api/hostfs.c stays portable. File I/O + entropy
-# seams follow in a later pass.
-if(WIN32)
+# dir_*/fs_* symbols (emu/plat.h), so api/hostfs.c stays portable. MinGW/Clang on
+# Windows get real POSIX headers from the mingw-w64 CRT, so they use posix/*.c like
+# every other non-MSVC platform; only MSVC lacks them.
+if(MSVC)
     target_sources(emu_core PRIVATE
         ${RP6502_SRC}/emu/win/dir.c
         ${RP6502_SRC}/emu/win/fs.c)
@@ -116,7 +117,9 @@ target_include_directories(emu_core PUBLIC
     ${RP6502_VENDOR}/chips
     ${RP6502_VENDOR}/sokol
 )
-target_compile_definitions(emu_core PUBLIC _GNU_SOURCE RP6502_EXFAT=0)
+# _POSIX_THREAD_SAFE_FUNCTIONS unlocks mingw-w64's inline localtime_r/gmtime_r
+# (time.h gates them on it); harmless elsewhere, where glibc implies it via _GNU_SOURCE.
+target_compile_definitions(emu_core PUBLIC _GNU_SOURCE _POSIX_THREAD_SAFE_FUNCTIONS RP6502_EXFAT=0)
 # MSVC has no separate libm
 if(NOT MSVC)
     target_link_libraries(emu_core PUBLIC m)

--- a/src/emu/api/clk.c
+++ b/src/emu/api/clk.c
@@ -14,10 +14,38 @@
 #include <locale.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
 
 #if defined(__APPLE__)
 size_t strftime_l(char *restrict, size_t, const char *restrict,
                   const struct tm *restrict, locale_t);
+#endif
+
+#ifdef _WIN32
+/* mingw/MSVC have no POSIX-2008 locale_t/newlocale/strftime_l; both provide
+ * the same shapes under an underscore, with LC_ALL implied instead of a mask. */
+typedef _locale_t locale_t;
+#define LC_ALL_MASK LC_ALL
+#define strftime_l _strftime_l
+
+/* _create_locale(LC_ALL, "") means "the OS's Control Panel locale", ignoring
+ * LC_ALL/LANG entirely -- unlike POSIX newlocale's "" (environment-driven).
+ * Read the env vars ourselves so `LC_ALL=C` (e.g. in tests) behaves the same
+ * on Windows as it does on POSIX. */
+static locale_t win_newlocale(const char *name)
+{
+    if (!name || !*name)
+    {
+        const char *env = getenv("LC_ALL");
+        if (!env || !*env)
+            env = getenv("LANG");
+        name = (env && *env) ? env : "";
+    }
+    return _create_locale(LC_ALL, name);
+}
+#define newlocale(mask, name, base) win_newlocale(name)
 #endif
 
 /* Host locale used only for strftime, so the rest of the process stays in the

--- a/src/emu/api/pro.c
+++ b/src/emu/api/pro.c
@@ -7,6 +7,7 @@
 
 #include "emu/api/pro.h"
 #include "emu/host/msc.h"
+#include "emu/plat.h"
 #include "emu/sys/mem.h"
 #include "emu/chips/rp6502.h"
 #include "emu/sys/cpu.h"
@@ -146,7 +147,7 @@ bool pro_set_argv(const char *rom, int argc, char *const *args)
 {
     char abs[MSC_MAX_PATH], msc[MSC_MAX_PATH];
     const char *argv0 = rom;
-    if (!msc_has_drive_prefix(rom) && rom[0] != ':' && realpath(rom, abs))
+    if (!msc_has_drive_prefix(rom) && rom[0] != ':' && fs_realpath(rom, abs))
     {
         msc_from_host(abs, msc, sizeof(msc));
         argv0 = msc;

--- a/src/emu/host/msc.c
+++ b/src/emu/host/msc.c
@@ -75,6 +75,9 @@ static int flags_to_posix(uint8_t flags)
         o |= O_EXCL;
     if ((flags & 0x20) && wr) /* TRUNC, only when opened for write */
         o |= O_TRUNC;
+#ifdef _WIN32
+    o |= O_BINARY; /* else the CRT's text-mode read stops at a 0x1A byte */
+#endif
     return o;
 }
 

--- a/src/emu/mon/rom.c
+++ b/src/emu/mon/rom.c
@@ -21,6 +21,16 @@
 #ifdef EMU_HAVE_AIO
 #include <aio.h>
 #endif
+#ifdef _WIN32
+/* mingw/MSVC have lseek/read but no pread(). Each rom_window owns a private
+ * fd (opened per-window, never shared), so seek-then-read is safe here. */
+static ssize_t pread(int fd, void *buf, size_t count, off_t offset)
+{
+    if (lseek(fd, offset, SEEK_SET) < 0)
+        return -1;
+    return read(fd, buf, (unsigned int)count);
+}
+#endif
 
 /* ------------------------------------------------------------------ */
 /* ROM: drive — read-only assets, windows into the loaded .rp6502      */
@@ -158,7 +168,11 @@ static struct rom_window *rom_win(int desc)
 /* Open a read-only [base, base+len) window on hostpath. desc >= 0, or -1 + *err. */
 static int rom_window_open(const char *hostpath, size_t base, size_t len, api_errno *err)
 {
+#ifdef _WIN32
+    int fd = open(hostpath, O_RDONLY | O_BINARY); /* else text-mode stops at 0x1A */
+#else
     int fd = open(hostpath, O_RDONLY);
+#endif
     if (fd < 0)
     {
         *err = msc_errno_to_api_errno(errno);

--- a/src/emu/plat.h
+++ b/src/emu/plat.h
@@ -58,6 +58,9 @@ bool fs_remove(const char *path);     /* a file or an empty directory */
 /* ---- misc primitives ---- */
 void fs_localtime(time_t t, struct tm *out);
 int fs_strcasecmp(const char *a, const char *b);
+/* Canonicalize an existing path (symlinks/./.. resolved); like POSIX realpath(3),
+ * fails if the target doesn't exist. resolved must hold at least PATH_MAX bytes. */
+char *fs_realpath(const char *path, char *resolved);
 
 #ifdef __cplusplus
 }

--- a/src/emu/posix/dir.c
+++ b/src/emu/posix/dir.c
@@ -9,14 +9,56 @@
 #include <dirent.h>
 #include <errno.h>
 #include <stdio.h>
+#ifdef _WIN32
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/* mingw's dirent carries no d_type; wrap DIR* with its path so dir_read can
+ * stat() each entry instead. */
+struct win_dir
+{
+    DIR *dir;
+    char *path;
+};
+#endif
 
 void *dir_open(const char *path)
 {
+#ifdef _WIN32
+    DIR *dir = opendir(path);
+    if (!dir)
+        return NULL;
+    struct win_dir *wd = malloc(sizeof(*wd));
+    if (!wd || !(wd->path = strdup(path)))
+    {
+        closedir(dir);
+        free(wd);
+        errno = ENOMEM;
+        return NULL;
+    }
+    wd->dir = dir;
+    return wd;
+#else
     return opendir(path);
+#endif
 }
 
 int dir_read(void *d, char *name, size_t namesz, bool *is_dir)
 {
+#ifdef _WIN32
+    struct win_dir *wd = (struct win_dir *)d;
+    errno = 0;
+    struct dirent *de = readdir(wd->dir);
+    if (!de)
+        return errno ? -1 : 0;
+    snprintf(name, namesz, "%s", de->d_name);
+    char full[1024];
+    snprintf(full, sizeof full, "%s/%s", wd->path, de->d_name);
+    struct stat st;
+    *is_dir = (stat(full, &st) == 0) && S_ISDIR(st.st_mode);
+    return 1;
+#else
     errno = 0;
     struct dirent *de = readdir((DIR *)d);
     if (!de)
@@ -24,14 +66,26 @@ int dir_read(void *d, char *name, size_t namesz, bool *is_dir)
     snprintf(name, namesz, "%s", de->d_name);
     *is_dir = (de->d_type == DT_DIR);
     return 1;
+#endif
 }
 
 void dir_rewind(void *d)
 {
+#ifdef _WIN32
+    rewinddir(((struct win_dir *)d)->dir);
+#else
     rewinddir((DIR *)d);
+#endif
 }
 
 void dir_close(void *d)
 {
+#ifdef _WIN32
+    struct win_dir *wd = (struct win_dir *)d;
+    closedir(wd->dir);
+    free(wd->path);
+    free(wd);
+#else
     closedir((DIR *)d);
+#endif
 }

--- a/src/emu/posix/fs.c
+++ b/src/emu/posix/fs.c
@@ -6,14 +6,19 @@
  */
 
 #include "emu/plat.h"
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
-#include <sys/statvfs.h>
 #include <time.h>
 #include <unistd.h>
 #include <utime.h>
+#ifdef _WIN32
+#include <windows.h> /* mingw has no sys/statvfs.h; GetDiskFreeSpaceExA covers fs_freespace */
+#else
+#include <sys/statvfs.h>
+#endif
 
 bool fs_stat(const char *path, struct fs_meta *out)
 {
@@ -33,6 +38,14 @@ bool fs_stat(const char *path, struct fs_meta *out)
 
 bool fs_freespace(const char *path, uint64_t *total_bytes, uint64_t *avail_bytes)
 {
+#ifdef _WIN32
+    ULARGE_INTEGER avail, total;
+    if (!GetDiskFreeSpaceExA(path, &avail, &total, NULL))
+        return false;
+    *total_bytes = total.QuadPart;
+    *avail_bytes = avail.QuadPart;
+    return true;
+#else
     struct statvfs vfs;
     if (statvfs(path, &vfs) != 0)
         return false;
@@ -40,6 +53,7 @@ bool fs_freespace(const char *path, uint64_t *total_bytes, uint64_t *avail_bytes
     *total_bytes = (uint64_t)vfs.f_blocks * unit;
     *avail_bytes = (uint64_t)vfs.f_bavail * unit;
     return true;
+#endif
 }
 
 bool fs_set_readonly(const char *path, bool readonly)
@@ -64,7 +78,11 @@ bool fs_set_mtime(const char *path, time_t mtime)
 
 bool fs_mkdir(const char *path)
 {
+#ifdef _WIN32
+    return mkdir(path) == 0; /* mingw's mkdir takes no mode */
+#else
     return mkdir(path, 0777) == 0;
+#endif
 }
 
 bool fs_chdir(const char *path)
@@ -74,7 +92,14 @@ bool fs_chdir(const char *path)
 
 bool fs_getcwd(char *buf, size_t sz)
 {
-    return getcwd(buf, sz) != NULL;
+    if (!getcwd(buf, sz))
+        return false;
+#ifdef _WIN32
+    for (char *p = buf; *p; p++) /* rest of the codebase is '/'-separated */
+        if (*p == '\\')
+            *p = '/';
+#endif
+    return true;
 }
 
 bool fs_rename(const char *oldp, const char *newp)
@@ -95,4 +120,23 @@ void fs_localtime(time_t t, struct tm *out)
 int fs_strcasecmp(const char *a, const char *b)
 {
     return strcasecmp(a, b);
+}
+
+char *fs_realpath(const char *path, char *resolved)
+{
+#ifdef _WIN32
+    /* mingw/MSVC have no realpath(); _fullpath() doesn't check existence like
+     * POSIX realpath() does, so stat() first to match the semantics callers rely on. */
+    struct stat st;
+    if (stat(path, &st) != 0)
+        return NULL;
+    if (!_fullpath(resolved, path, PATH_MAX))
+        return NULL;
+    for (char *p = resolved; *p; p++) /* rest of the codebase is '/'-separated */
+        if (*p == '\\')
+            *p = '/';
+    return resolved;
+#else
+    return realpath(path, resolved);
+#endif
 }

--- a/src/emu/tests/test_dir.c
+++ b/src/emu/tests/test_dir.c
@@ -16,6 +16,7 @@
 #include "emu/sys/com.h"
 #include "emu/mon/rom.h"
 #include "emu/api/hostfs.h"
+#include "emu/plat.h"
 #include "emu/sys/cpu.h"
 #include "emu/main.h"
 #include "utest.h"
@@ -24,6 +25,26 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+/* POSIX always has /tmp; Windows doesn't, so ask the OS for its temp dir. */
+static const char *test_tmp_base(void)
+{
+#ifdef _WIN32
+    static char buf[512];
+    const char *t = getenv("TEMP");
+    if (!t || !*t)
+        t = getenv("TMP");
+    if (!t || !*t)
+        return ".";
+    size_t i = 0;
+    for (; t[i] && i + 1 < sizeof buf; i++)
+        buf[i] = t[i] == '\\' ? '/' : t[i];
+    buf[i] = 0;
+    return buf;
+#else
+    return "/tmp";
+#endif
+}
 
 static char cap[1 << 16];
 static size_t cap_len;
@@ -49,14 +70,15 @@ static void write_file(const char *dir, const char *name, const char *data)
 
 UTEST(dir, lists_directory)
 {
-    char tmpl[] = "/tmp/dir_rom_test_XXXXXX";
+    char tmpl[512];
+    snprintf(tmpl, sizeof tmpl, "%s/dir_rom_test_XXXXXX", test_tmp_base());
     const char *d = mkdtemp(tmpl);
     ASSERT_TRUE(d != NULL);
     write_file(d, "alpha.txt", "hello");             /* 5 bytes */
     write_file(d, "beta.dat", "wider content here");  /* 18 bytes */
     char sub[512];
     snprintf(sub, sizeof(sub), "%s/subdir", d);
-    ASSERT_EQ(mkdir(sub, 0777), 0);
+    ASSERT_TRUE(fs_mkdir(sub));
 
     ASSERT_TRUE(chdir(d) == 0); /* the program lists "" = the cwd */
     ASSERT_TRUE(rom_load(DIR_ROM));

--- a/src/emu/tests/test_drive.c
+++ b/src/emu/tests/test_drive.c
@@ -18,6 +18,7 @@
 #include "emu/mon/rom.h"
 #include "emu/api/hostfs.h"
 #include "emu/host/msc.h"
+#include "emu/plat.h"
 #include "emu/sys/mem.h"
 #include "emu/api/tmpfs.h"
 #include "fatfs/ff.h"
@@ -34,14 +35,35 @@
 #define O_CREAT_ 0x10
 #define O_TRUNC_ 0x20
 
+/* POSIX always has /tmp; Windows doesn't, so ask the OS for its temp dir. */
+static const char *test_tmp_base(void)
+{
+#ifdef _WIN32
+    static char buf[512];
+    const char *t = getenv("TEMP");
+    if (!t || !*t)
+        t = getenv("TMP");
+    if (!t || !*t)
+        return ".";
+    size_t i = 0;
+    for (; t[i] && i + 1 < sizeof buf; i++)
+        buf[i] = t[i] == '\\' ? '/' : t[i];
+    buf[i] = 0;
+    return buf;
+#else
+    return "/tmp";
+#endif
+}
+
 static char g_dir[256]; /* a temp dir, made the MSC0: mount */
 
 static bool fresh(void)
 {
-    char tmpl[] = "/tmp/drive_test_XXXXXX";
+    char tmpl[512];
+    snprintf(tmpl, sizeof tmpl, "%s/drive_test_XXXXXX", test_tmp_base());
     const char *d = mkdtemp(tmpl);
     char resolved[MSC_MAX_PATH];
-    if (!d || !realpath(d, resolved) || strlen(resolved) >= sizeof(g_dir))
+    if (!d || !fs_realpath(d, resolved) || strlen(resolved) >= sizeof(g_dir))
         return false;
     strcpy(g_dir, resolved);
     std_stop();
@@ -145,10 +167,10 @@ UTEST(drive, mount_transparent_no_chroot)
 {
     ASSERT_TRUE(fresh()); /* cwd = g_dir */
 
-    char cwd[MSC_MAX_PATH], expect[MSC_MAX_PATH];
+    char cwd[MSC_MAX_PATH], expect[MSC_MAX_PATH], hostbuf[MSC_MAX_PATH];
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s", g_dir); /* getcwd is the native cwd */
+    msc_from_host(g_dir, expect, sizeof(expect)); /* getcwd is the native cwd */
     ASSERT_STREQ(cwd, expect);
 
     /* A relative MSC0: path lands in the cwd (= g_dir). */
@@ -171,7 +193,8 @@ UTEST(drive, mount_transparent_no_chroot)
     ASSERT_EQ(dsys_ax(), 0);
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s/sub", g_dir);
+    snprintf(hostbuf, sizeof(hostbuf), "%s/sub", g_dir);
+    msc_from_host(hostbuf, expect, sizeof(expect));
     ASSERT_STREQ(cwd, expect);
 
     /* ".." climbs back to the launch dir, then ABOVE it — no confinement (the
@@ -181,7 +204,7 @@ UTEST(drive, mount_transparent_no_chroot)
     ASSERT_EQ(dsys_ax(), 0);
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s", g_dir);
+    msc_from_host(g_dir, expect, sizeof(expect));
     ASSERT_STREQ(cwd, expect);
     dsys_path("..");
     hostfs_api_chdir();

--- a/src/emu/tests/test_exec.c
+++ b/src/emu/tests/test_exec.c
@@ -14,6 +14,7 @@
 #include "emu/sys/com.h"
 #include "emu/mon/rom.h"
 #include "emu/host/msc.h"
+#include "emu/plat.h"
 #include "emu/sys/cpu.h"
 #include "emu/main.h"
 #include "utest.h"
@@ -49,7 +50,7 @@ UTEST(exec, reexecs_self_with_arg)
      * `rp6502-emu exec.rp6502` from that dir); argv[0] is the absolute native
      * MSC0: path and round-trips through the exec resolver. */
     char abs[MSC_MAX_PATH], msc[MSC_MAX_PATH], dir[MSC_MAX_PATH];
-    ASSERT_TRUE(realpath(EXEC_ROM, abs) != NULL);
+    ASSERT_TRUE(fs_realpath(EXEC_ROM, abs) != NULL);
     snprintf(dir, sizeof(dir), "%s", abs);
     char *slash = strrchr(dir, '/');
     ASSERT_TRUE(slash != NULL);

--- a/src/emu/tests/test_features.c
+++ b/src/emu/tests/test_features.c
@@ -22,7 +22,28 @@
 #include "stdsys.h"
 #include "utest.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+/* POSIX always has /tmp; Windows doesn't, so ask the OS for its temp dir. */
+static const char *test_tmp_base(void)
+{
+#ifdef _WIN32
+    static char buf[512];
+    const char *t = getenv("TEMP");
+    if (!t || !*t)
+        t = getenv("TMP");
+    if (!t || !*t)
+        return ".";
+    size_t i = 0;
+    for (; t[i] && i + 1 < sizeof buf; i++)
+        buf[i] = t[i] == '\\' ? '/' : t[i];
+    buf[i] = 0;
+    return buf;
+#else
+    return "/tmp";
+#endif
+}
 
 /* SIGINT: a Ctrl-C latches, is reported once via the attribute, and (only when
  * the program enabled the $FFF0 IRQ) asserts the CPU's IRQ line until read. */
@@ -192,7 +213,8 @@ UTEST(features, audio_disable)
  * CPU). Returns the path, or NULL on a write failure. */
 static const char *make_asset_rom(const char *args)
 {
-    static const char *path = "/tmp/emu_asset_test.rp6502";
+    static char path[512];
+    snprintf(path, sizeof path, "%s/emu_asset_test.rp6502", test_tmp_base());
     uint8_t vec[2] = {0x00, 0x02}; /* reset vector -> $0200 */
     char rec[64];
     int reclen = snprintf(rec, sizeof rec, "$FFFC $2 $%08X\r\n", rom_crc32(0, vec, 2));

--- a/src/emu/tests/test_fs.c
+++ b/src/emu/tests/test_fs.c
@@ -15,6 +15,7 @@
 #include "emu/mon/rom.h"
 #include "emu/api/hostfs.h"
 #include "emu/host/msc.h"
+#include "emu/plat.h"
 #include "dirsys.h"
 #include "stdsys.h"
 #include "utest.h"
@@ -29,14 +30,35 @@
 #define O_CREAT_ 0x10
 #define O_TRUNC_ 0x20
 
+/* POSIX always has /tmp; Windows doesn't, so ask the OS for its temp dir. */
+static const char *test_tmp_base(void)
+{
+#ifdef _WIN32
+    static char buf[512];
+    const char *t = getenv("TEMP");
+    if (!t || !*t)
+        t = getenv("TMP");
+    if (!t || !*t)
+        return ".";
+    size_t i = 0;
+    for (; t[i] && i + 1 < sizeof buf; i++)
+        buf[i] = t[i] == '\\' ? '/' : t[i];
+    buf[i] = 0;
+    return buf;
+#else
+    return "/tmp";
+#endif
+}
+
 static char g_dir[256]; /* a temp dir, made the MSC0: cwd */
 
 static bool fresh_cwd(void)
 {
-    char tmpl[] = "/tmp/msc0_test_XXXXXX";
+    char tmpl[512];
+    snprintf(tmpl, sizeof tmpl, "%s/msc0_test_XXXXXX", test_tmp_base());
     const char *d = mkdtemp(tmpl);
     char resolved[MSC_MAX_PATH]; /* realpath needs a PATH_MAX buffer */
-    if (!d || !realpath(d, resolved) || strlen(resolved) >= sizeof(g_dir))
+    if (!d || !fs_realpath(d, resolved) || strlen(resolved) >= sizeof(g_dir))
         return false;
     strcpy(g_dir, resolved);
     std_stop(); /* close any files a prior test left open */
@@ -90,10 +112,10 @@ UTEST(fs, chdir_getcwd_relative)
 {
     ASSERT_TRUE(fresh_cwd());
 
-    char cwd[MSC_MAX_PATH], expect[MSC_MAX_PATH];
+    char cwd[MSC_MAX_PATH], expect[MSC_MAX_PATH], hostbuf[MSC_MAX_PATH];
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s", g_dir); /* getcwd is the native cwd */
+    msc_from_host(g_dir, expect, sizeof(expect)); /* getcwd is the native cwd */
     ASSERT_STREQ(cwd, expect);
 
     dsys_path("saves");
@@ -104,7 +126,8 @@ UTEST(fs, chdir_getcwd_relative)
     ASSERT_EQ(dsys_ax(), 0);
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s/saves", g_dir);
+    snprintf(hostbuf, sizeof(hostbuf), "%s/saves", g_dir);
+    msc_from_host(hostbuf, expect, sizeof(expect));
     ASSERT_STREQ(cwd, expect);
 
     /* A relative path resolves under the new cwd. */
@@ -130,10 +153,11 @@ UTEST(fs, no_chroot_clamp)
     dsys_path("sub");
     hostfs_api_chdir();
     ASSERT_EQ(dsys_ax(), 0);
-    char cwd[MSC_MAX_PATH], expect[MSC_MAX_PATH];
+    char cwd[MSC_MAX_PATH], expect[MSC_MAX_PATH], hostbuf[MSC_MAX_PATH];
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s/sub", g_dir);
+    snprintf(hostbuf, sizeof(hostbuf), "%s/sub", g_dir);
+    msc_from_host(hostbuf, expect, sizeof(expect));
     ASSERT_STREQ(cwd, expect);
 
     /* ".." climbs back to the launch dir ... */
@@ -142,7 +166,7 @@ UTEST(fs, no_chroot_clamp)
     ASSERT_EQ(dsys_ax(), 0);
     hostfs_api_getcwd();
     dsys_str(cwd, sizeof(cwd));
-    snprintf(expect, sizeof(expect), "MSC0:%s", g_dir);
+    msc_from_host(g_dir, expect, sizeof(expect));
     ASSERT_STREQ(cwd, expect);
 
     /* ... and again climbs ABOVE it — no clamp; the cwd walks the real tree. */

--- a/src/emu/tests/test_rtc.c
+++ b/src/emu/tests/test_rtc.c
@@ -23,8 +23,28 @@
 #include "api/api.h"
 #include "api/clk.h"
 #include "utest.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+/* mingw/MSVC have no setenv(); _putenv() takes "NAME=value" and always overwrites. */
+static int setenv(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    char buf[256];
+    snprintf(buf, sizeof buf, "%s=%s", name, value);
+    return _putenv(buf);
+}
+#endif
+
+/* clk.c's g_locale is resolved from LC_ALL once and cached for the process.
+ * Other UTESTs in this binary call main_init() (-> clk_reset()) before this
+ * one gets to setenv("LC_ALL", "C", 1) below, which would otherwise cache
+ * whichever locale the host happens to default to. Force it before main(). */
+__attribute__((constructor)) static void force_c_locale(void)
+{
+    setenv("LC_ALL", "C", 1);
+}
 
 static char cap[1 << 16];
 static size_t cap_len;


### PR DESCRIPTION
## Windows emulator support (MSYS2/UCRT64)

Ports `src/emu` to build and run natively on Windows via MSYS2's UCRT64 GCC toolchain
(previously unsupported — README said "nobody is working on the emulator for Windows").

- Close mingw's POSIX gaps (no `d_type`, `<sys/statvfs.h>`, `pread`, POSIX locale API,
  1-arg `mkdir`) in `posix/dir.c`, `posix/fs.c`, `api/clk.c`, `api/pro.c`, `host/msc.c`,
  `mon/rom.c`; add `fs_realpath()` to the `plat.h` seam.
- Statically link the MinGW runtime so `rp6502-emu.exe` runs standalone (no MSYS2 needed at
  runtime).
- Fix Windows gaps in the test suite (`mkdir`/`realpath`/`setenv`, no `/tmp`).
- Fix Windows F5 debugging (`launch.json`).

All 20 `ctest` suites pass; D3D11 window renders. Setup/troubleshooting:
`EMULATOR_WINDOWS_MSYS2_VSCODE.md`.

<img width="1706" height="1025" alt="obraz" src="https://github.com/user-attachments/assets/38cc8743-5875-4eb3-bc21-91de37ae6ff1" />
